### PR TITLE
Fix authentication for MySQL health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       dockerhero:
         ipv4_address: 172.25.0.13
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping"]
+      test: ["CMD", "mysqladmin", "-pdockerhero", "ping"]
 
   mail:
     container_name: dockerhero_mail


### PR DESCRIPTION
I kept seeing this error message, twice per minute:

```
[Note] Access denied for user 'root'@'localhost' (using password: NO)
```

This fixes it.